### PR TITLE
Fixed package name in open api.

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -13,7 +13,8 @@ packages, for the generated files:
 ### Configuration
 * `serverOpenApiFile` is the path to the OpenAPI specification file. You can set this property
   in `gradle.properties`. If it is not set, the OpenAPI generator will not be invoked.
-
+* With `serverOpenApiPackage` you can control the base package name of the generated code.
+  It defaults to `com.dt.<project-name>`.
 
 ### Defaults
 There is no default configuration.

--- a/src/main/resources/openapi.gradle
+++ b/src/main/resources/openapi.gradle
@@ -6,6 +6,7 @@ dependencies {
 
 if (project.hasProperty('serverOpenApiFile')) {
     final OPENAPI_FILE = project.ext['serverOpenApiFile'];
+    final PACKAGE_NAME = project.ext['serverOpenApiPackage'] ?: "com.dt.${project.name.replace('-', '.')}"
     final API_ROOT = "${buildDir}/generated/api"
 
     // generate APIs (interfaces and models only) using the provided openapi.yaml
@@ -14,10 +15,10 @@ if (project.hasProperty('serverOpenApiFile')) {
         skipValidateSpec = false
         inputSpec = OPENAPI_FILE
         outputDir = API_ROOT
-        apiPackage = "com.dt.${project.name}.api"
-        modelPackage = "com.dt.${project.name}.dto"
+        apiPackage = "${PACKAGE_NAME}.api"
+        modelPackage = "${PACKAGE_NAME}.dto"
         configOptions = [
-                basePackage                : "com.dt.${project.name}",
+                basePackage                : "${PACKAGE_NAME}",
                 interfaceOnly              : "true",
                 skipDefaultInterface       : "true",
                 // hateoas: "true",


### PR DESCRIPTION
**What is this about?**

The service name might be 'adapter-moroso-quotes'. But this is not a valid package name. So in this PR i'm replacing dashes with dots. And I'm adding a new configuration variable to control the generate package name.