### PR TITLE
fix spotless year license header

### DIFF
--- a/src/main/resources/formatter.gradle
+++ b/src/main/resources/formatter.gradle
@@ -16,7 +16,7 @@ spotless {
         if (!project.hasProperty('skipLicenseHeader')) {
             licenseHeader """\
 /*
- * Copyright (C) ${new Date().getYear() + 1900} Design Technologies - All Rights Reserved
+ * Copyright (C) \$YEAR Design Technologies - All Rights Reserved
  * Unauthorized copying of this file via any medium is strictly prohibited.
  * Proprietary and confidential.
  * Please send any inquiries to our Support Team <support@designtechnologies.com>


### PR DESCRIPTION
The spotless plugin will keep updating the header year, even when this is not needed. With this fix, the "new year problem" is solved.