### PR TITLE
Include only production runtime dependencies in the docker image - ex…

### DIFF
--- a/src/main/resources/docker.gradle
+++ b/src/main/resources/docker.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.google.cloud.tools.jib'
 
-
 ext.getDockerImage = { ->
     def registry = System.env.DOCKER_REGISTRY ?: ""
     def version = System.env.DOCKER_IMAGE_VERSION ?: "latest"
@@ -11,6 +10,10 @@ ext.getDockerImage = { ->
 }
 
 jib {
+    // use spring boot production runtime classpath in order to not include dev only dependencies
+    // like spring dev tools
+    // more info: https://github.com/GoogleContainerTools/jib/issues/2336#issuecomment-849778769
+    configurationName = "productionRuntimeClasspath"
     from { image = "amazoncorretto:17" }
     to { image = getDockerImage() }
     container {


### PR DESCRIPTION
…cluding spring dev-tools

Tried [jib-spring-boot-extension-maven](https://github.com/GoogleContainerTools/jib-extensions/tree/master/first-party/jib-spring-boot-extension-maven) - without any success, probably because of our complex build script structure.
That's why I am using this solution - https://github.com/GoogleContainerTools/jib/issues/2336#issuecomment-849778769